### PR TITLE
Corrected dialog width when using custom width

### DIFF
--- a/SynTaskDialog.pas
+++ b/SynTaskDialog.pas
@@ -863,7 +863,7 @@ begin
     Config.hFooterIcon := TD_FOOTERICONS[aFooterIcon];
     Config.nDefaultButton := aButtonDef;
     Config.nDefaultRadioButton := aRadioDef;
-    Config.cxWidth := aWidth;
+    Config.cxWidth := round(aWidth / (LOWORD(GetDialogBaseUnits()) / 4));
     Config.pfCallback := @TaskDialogCallbackProc;
     Config.lpCallbackData := @self;
     if TaskDialogIndirect(@Config,@result,@RadioRes,@VerifyChecked)=S_OK then


### PR DESCRIPTION
When using "TaskDialogIndirect" function, "Config.cxWidth" parameter should be measured in dialog units (see https://docs.microsoft.com/en-us/windows/win32/api/commctrl/ns-commctrl-taskdialogconfig), but "aWidth" is in pixels (according to "Execute" function description). Therefore, we need to either correct the function description (say that "aWidth" is measured in dialog units), or the code.